### PR TITLE
Bundler as dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gem "nokogiri", "~> 1.5.0"
 gem "sax-machine", "~> 0.1.0"
 
 group :development do
-  gem "bundler", "~> 1.0.21"
   gem "fakeweb", "~> 1.3.0"
   gem "jeweler", "~> 1.8.3"
   gem "rspec", "~> 2.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.0.21)
   fakeweb (~> 1.3.0)
   jeweler (~> 1.8.3)
   log-me (~> 0.0.2)


### PR DESCRIPTION
I'm trying to install correios-frete in a project I'm working on but I'm getting this:

```
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    correios-frete (= 0.2.1) ruby depends on
      bundler (~> 1.0.0) ruby

  Current Bundler version:
    bundler (1.1.rc.7)

This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?
```

I'm using the RC7 of bundler (since it's faster) and right now I'm unable to run a `bundle install`. Please, consider remove it from Gemfile
