### PR TITLE
adicionando PAC GF na lista de servicos disponiveis

### DIFF
--- a/lib/correios/frete/servico.rb
+++ b/lib/correios/frete/servico.rb
@@ -9,6 +9,7 @@ module Correios
       AVAILABLE_SERVICES = {
         "41106" => { :type => :pac,                         :name => "PAC",            :description => "PAC sem contrato"                  },
         "41068" => { :type => :pac_com_contrato,            :name => "PAC",            :description => "PAC com contrato"                  },
+        "41300" => { :type => :pac_gf,                      :name => "PAC GF",         :description => "PAC para grandes formatos"         },
         "40010" => { :type => :sedex,                       :name => "SEDEX",          :description => "SEDEX sem contrato"                },
         "40045" => { :type => :sedex_a_cobrar,              :name => "SEDEX a Cobrar", :description => "SEDEX a Cobrar, sem contrato"      },
         "40126" => { :type => :sedex_a_cobrar_com_contrato, :name => "SEDEX a Cobrar", :description => "SEDEX a Cobrar, com contrato"      },


### PR DESCRIPTION
Olá

Conforme [página dos Correios](http://www.correios.com.br/produtosaz/produto.cfm?id=77493588-5056-9163-89AC858354B50479), há agora uma forma de envio nova: o PAC para Grandes Formatos.

Essa forma é somente permitida mediante contrato, e suporta encomendas com medida máxima de até 150cm. O valor e o prazo são aumentados.

Já consta na resposta do WebService dos Correios.

Espero que ajude!
