### PR TITLE
Controle adicional no limite de dimensões

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,4 +1,7 @@
-== Versão 1.9.3
+== Versão 1.9.5
+- Adicionado tratamento de limites máximos de dimensões. Quando algum item de um pacote possui dimensões maiores que as permitidas pelos Correios, essas medidas são informadas diretamente ao webservice dos Correios.
+
+== Versão 1.9.4
 - Atualização: Versão 0.0.10 da gem log-me.
 
 == Versão 1.9.3

--- a/lib/correios/frete/pacote.rb
+++ b/lib/correios/frete/pacote.rb
@@ -10,6 +10,12 @@ module Correios
         :altura => 2.0
       }
 
+      MAX_DIMENSIONS = {
+        :comprimento => 105.0,
+        :largura => 105.0,
+        :altura => 105.0
+      }
+
       def initialize(itens = nil)
         @peso = @comprimento = @largura = @altura = @volume = 0.0
         @itens = []
@@ -48,8 +54,9 @@ module Correios
           @largura = item.largura
           @altura = item.altura
         else
-          dimensao = @volume.to_f**(1.0/3)
-          @comprimento = @largura = @altura = dimensao
+          @comprimento = comprimento_itens
+          @largura = largura_itens
+          @altura = altura_itens
         end
 
         min_dimension_values
@@ -63,6 +70,29 @@ module Correios
 
       def min(value, minimum)
         (value < minimum) ? minimum : value
+      end
+
+      def max(value, maximum)
+        (value >= maximum) ? value : maximum
+      end
+
+      def dimensao
+        @volume.to_f**(1.0/3)
+      end
+
+      def comprimento_itens
+        max = @itens.map(&:comprimento).max
+        max >= MAX_DIMENSIONS[:comprimento] ? max : dimensao
+      end
+
+      def largura_itens
+        max = @itens.map(&:largura).max
+        max >= MAX_DIMENSIONS[:largura] ? max : dimensao
+      end
+
+      def altura_itens
+        max = @itens.map(&:altura).max
+        max >= MAX_DIMENSIONS[:altura] ? max : dimensao
       end
     end
   end

--- a/lib/correios/frete/version.rb
+++ b/lib/correios/frete/version.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 module Correios
   module Frete
-    VERSION = "1.9.4"
+    VERSION = "1.9.5"
   end
 end

--- a/spec/correios/frete/pacote_spec.rb
+++ b/spec/correios/frete/pacote_spec.rb
@@ -141,6 +141,13 @@ describe Correios::Frete::Pacote do
 
         @pacote.adicionar_item(@item1)
         @pacote.adicionar_item(@item2)
+
+        @exceeded_dimensions = Correios::Frete::PacoteItem.new(
+          :altura => Correios::Frete::Pacote::MAX_DIMENSIONS[:altura] + 1,
+          :largura => Correios::Frete::Pacote::MAX_DIMENSIONS[:largura] + 1,
+          :comprimento => Correios::Frete::Pacote::MAX_DIMENSIONS[:comprimento] + 1,
+          :peso => 1.0
+        )
       end
 
       it "calculates package weight" do
@@ -181,6 +188,81 @@ describe Correios::Frete::Pacote do
 
         it "sets minimum height value" do
           expect(@pacote.altura).to eq(2)
+        end
+      end
+
+      context "with at least one item dimension greater than maximum" do
+        before :each do
+          over_lengthened = Correios::Frete::PacoteItem.new(:peso => 0.3, :largura => 1, :altura => 1,
+            :comprimento => @exceeded_dimensions.comprimento)
+
+          too_wide  = Correios::Frete::PacoteItem.new(:peso => 0.3, :comprimento => 3, :altura => 1,
+            :largura => @exceeded_dimensions.largura)
+
+          over_heightened = Correios::Frete::PacoteItem.new(:peso => 0.3, :comprimento => 3, :largura => 1,
+            :altura => @exceeded_dimensions.altura)
+
+          @pacote = Correios::Frete::Pacote.new
+          @pacote.adicionar_item(over_lengthened)
+          @pacote.adicionar_item(too_wide)
+          @pacote.adicionar_item(over_heightened)
+        end
+
+        it "shows biggest length value" do
+          expect(@pacote.comprimento).to eq(@exceeded_dimensions.comprimento)
+        end
+
+        it "shows biggest width value" do
+          expect(@pacote.largura).to eq(@exceeded_dimensions.largura)
+        end
+
+        it "shows biggest height value" do
+          expect(@pacote.altura).to eq(@exceeded_dimensions.altura)
+        end
+      end
+
+      context "over lengthed items with zero widht and height" do
+        before :each do
+          over_lengthened = Correios::Frete::PacoteItem.new(:peso => 0.3, :largura => 0, :altura => 0,
+            :comprimento => @exceeded_dimensions.comprimento)
+
+          @pacote = Correios::Frete::Pacote.new
+          2.times{@pacote.adicionar_item(over_lengthened)}
+        end
+
+        it "does not get length information from minimum dimensions" do
+          expect(@pacote.items.size).to eq(2)
+          expect(@pacote.comprimento).to_not eq(Correios::Frete::Pacote::MIN_DIMENSIONS[:comprimento])
+        end
+      end
+
+      context "over widthed items with zero length and height" do
+        before :each do
+          too_wide = Correios::Frete::PacoteItem.new(:peso => 0.3, :comprimento => 0, :altura => 0,
+            :largura => @exceeded_dimensions.largura)
+
+          @pacote = Correios::Frete::Pacote.new
+          2.times{@pacote.adicionar_item(too_wide)}
+        end
+
+        it "does not get width information from minimum dimensions" do
+          expect(@pacote.items.size).to eq(2)
+          expect(@pacote.largura).to_not eq(Correios::Frete::Pacote::MIN_DIMENSIONS[:largura])
+        end
+      end
+
+      context "over heighted items with zero widht and length" do
+        before :each do
+          over_heightened = Correios::Frete::PacoteItem.new(:peso => 0.3, :comprimento => 0, :largura => 0,
+            :altura => @exceeded_dimensions.altura)
+
+          @pacote = Correios::Frete::Pacote.new
+          2.times{@pacote.adicionar_item(over_heightened)}
+        end
+
+        it "does not get height information from minimum dimensions" do
+          expect(@pacote.items.size).to eq(2)
+          expect(@pacote.altura).to_not eq(Correios::Frete::Pacote::MIN_DIMENSIONS[:altura])
         end
       end
     end


### PR DESCRIPTION
### Este pull request sugere um refinamento no tratamento das dimensões de um pacote com mais de um item

### 1. Itens com dimensões maiores que o permitido pelos Correios:

Um item criado com parâmetros como:

```item = Correios::Frete::PacoteItem.new(
  :altura => 110,
  :largura => 20,
  :comprimento => 20,
  :peso => 0.1
)```

é recusado por exceder o limite de altura aceito pelos Correios (o limite atual é de 105 cm).

Ao adicionar dois ou mais desses itens em um pacote, o cálculo do volume total afeta o valor
das dimensões, inclusive da altura. Fazendo com que o pacote seja **aceito** pelos Correios :scream:

Este caso só se torna um problema quando os itens de um pacote não podem ser dobrados ou compactados de forma a ter suas dimensões reduzidas.

Este pull request sugere uma alternativa (mas **des**considera itens dobráveis).


### 2. Um pacote contendo itens em que ao menos uma dimensão é zero:

Ao adicionar um item com ao menos uma dimensão igual a zero:

```item = Correios::Frete::PacoteItem.new(
  :altura => 110,
  :largura => 0,
  :comprimento => 0,
  :peso => 0.1
)```

O pacote fica com altura `2.0`, pois ao menos uma de suas duas outras dimensões é `0`. O problema aqui é que novamente a altura será alterada para um valor menor que o real, e para os casos de objetos que não podem ser compactados, dobrados, etc., isso pode ser um inconveniente.

Este pull request sugere manter os valores mais altos quando os mesmos ultrapassarem os limites máximos aceitos pelos Correios.


### TODO:

Ainda resta um problema a ser resolvido, que é o caso de um item como este:

```item = Correios::Frete::PacoteItem.new(
  :altura => 100,
  :largura => 100,
  :comprimento => 1,
  :peso => 0.1
)```

ao adicionar um item, os Correios anunciam que não é permitido que a soma das dimensões ultrapasse 200 cm. Ao adicionar dois itens, as dimensões caem novamente no cálculo do volume total, baixando para um valor aceito pelos Correios.

Os commits foram todos feitos em inglês porque esse é o padrão aqui na firma. Mas procurei manter os padrões de código, nomenclatura de variáveis, etc.