### PR TITLE
Substituicao dos códigos do PAC e do SEDEX

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -164,16 +164,16 @@ Por padrão, cada chamada ao Web Service dos Correios é logada em STDOUT, com n
 
 Exemplo de log:
   I, [2011-10-01T00:26:16.864990 #5631]  INFO -- : Correios-Frete Request:
-  http://ws.correios.com.br/calculador/CalcPrecoPrazo.aspx?sCepOrigem=04094-050&sCepDestino=90619-900&nVlPeso=0.3&nVlComprimento=30&nVlAltura=2&nVlLargura=15&nVlDiametro=0.0&nCdFormato=1&sCdMaoPropria=N&sCdAvisoRecebimento=N&nVlValorDeclarado=0,00&nCdServico=41106&nCdEmpresa=&sDsSenha=&StrRetorno=xml
+  http://ws.correios.com.br/calculador/CalcPrecoPrazo.aspx?sCepOrigem=04094-050&sCepDestino=90619-900&nVlPeso=0.3&nVlComprimento=30&nVlAltura=2&nVlLargura=15&nVlDiametro=0.0&nCdFormato=1&sCdMaoPropria=N&sCdAvisoRecebimento=N&nVlValorDeclarado=0,00&nCdServico=04510&nCdEmpresa=&sDsSenha=&StrRetorno=xml
 
   I, [2011-10-01T00:26:17.121822 #5631]  INFO -- : Correios-Frete Response:
   HTTP/1.1 200 OK
   <?xml version="1.0" encoding="ISO-8859-1" ?>
-  <Servicos><cServico><Codigo>41106</Codigo><Valor>10,00</Valor><PrazoEntrega>5</PrazoEntrega><ValorMaoPropria>0,00</ValorMaoPropria><ValorAvisoRecebimento>0,00</ValorAvisoRecebimento><ValorValorDeclarado>0,00</ValorValorDeclarado><EntregaDomiciliar>S</EntregaDomiciliar><EntregaSabado>N</EntregaSabado><Erro>0</Erro><MsgErro></MsgErro></cServico></Servicos>
+  <Servicos><cServico><Codigo>04510</Codigo><Valor>10,00</Valor><PrazoEntrega>5</PrazoEntrega><ValorMaoPropria>0,00</ValorMaoPropria><ValorAvisoRecebimento>0,00</ValorAvisoRecebimento><ValorValorDeclarado>0,00</ValorValorDeclarado><EntregaDomiciliar>S</EntregaDomiciliar><EntregaSabado>N</EntregaSabado><Erro>0</Erro><MsgErro></MsgErro></cServico></Servicos>
 
 Se você configurar o nível de log como <b>:debug</b>, serão logados também todos os cabeçalhos HTTP da resposta:
   D, [2011-10-01T00:27:50.597961 #5631] DEBUG -- : Correios-Frete Request:
-  http://ws.correios.com.br/calculador/CalcPrecoPrazo.aspx?sCepOrigem=04094-050&sCepDestino=90619-900&nVlPeso=0.3&nVlComprimento=30&nVlAltura=2&nVlLargura=15&nVlDiametro=0.0&nCdFormato=1&sCdMaoPropria=N&sCdAvisoRecebimento=N&nVlValorDeclarado=0,00&nCdServico=41106&nCdEmpresa=&sDsSenha=&StrRetorno=xml
+  http://ws.correios.com.br/calculador/CalcPrecoPrazo.aspx?sCepOrigem=04094-050&sCepDestino=90619-900&nVlPeso=0.3&nVlComprimento=30&nVlAltura=2&nVlLargura=15&nVlDiametro=0.0&nCdFormato=1&sCdMaoPropria=N&sCdAvisoRecebimento=N&nVlValorDeclarado=0,00&nCdServico=04510&nCdEmpresa=&sDsSenha=&StrRetorno=xml
 
   D, [2011-10-01T00:27:50.812046 #5631] DEBUG -- : Correios-Frete Response:
   HTTP/1.1 200 OK
@@ -187,7 +187,7 @@ Se você configurar o nível de log como <b>:debug</b>, serão logados também t
   content-type: text/xml; charset=iso-8859-1
   content-length: 401
   <?xml version="1.0" encoding="ISO-8859-1" ?>
-  <Servicos><cServico><Codigo>41106</Codigo><Valor>10,00</Valor><PrazoEntrega>5</PrazoEntrega><ValorMaoPropria>0,00</ValorMaoPropria><ValorAvisoRecebimento>0,00</ValorAvisoRecebimento><ValorValorDeclarado>0,00</ValorValorDeclarado><EntregaDomiciliar>S</EntregaDomiciliar><EntregaSabado>N</EntregaSabado><Erro>0</Erro><MsgErro></MsgErro></cServico></Servicos>
+  <Servicos><cServico><Codigo>04510</Codigo><Valor>10,00</Valor><PrazoEntrega>5</PrazoEntrega><ValorMaoPropria>0,00</ValorMaoPropria><ValorAvisoRecebimento>0,00</ValorAvisoRecebimento><ValorValorDeclarado>0,00</ValorValorDeclarado><EntregaDomiciliar>S</EntregaDomiciliar><EntregaSabado>N</EntregaSabado><Erro>0</Erro><MsgErro></MsgErro></cServico></Servicos>
 
 Para desabilitar o log, mudar o nível do log ou configurar um outro mecanismo de log, use o módulo <b>Correios::Frete</b>.
 
@@ -209,10 +209,10 @@ Para desabilitar o log, mudar o nível do log ou configurar um outro mecanismo d
 
 === Serviços suportados
 
-  :pac                         # 41106 - PAC sem contrato
+  :pac                         # 04510 - PAC sem contrato
   :pac_com_contrato            # 41068 - PAC com contrato
   :pac_gf                      # 41300 - PAC para grandes formatos
-  :sedex                       # 40010 - SEDEX sem contrato
+  :sedex                       # 04014 - SEDEX sem contrato
   :sedex_a_cobrar              # 40045 - SEDEX a Cobrar, sem contrato
   :sedex_a_cobrar_com_contrato # 40126 - SEDEX a Cobrar, com contrato
   :sedex_10                    # 40215 - SEDEX 10, sem contrato

--- a/lib/correios/frete/servico.rb
+++ b/lib/correios/frete/servico.rb
@@ -7,10 +7,10 @@ module Correios
       include SAXMachine
 
       AVAILABLE_SERVICES = {
-        "41106" => { :type => :pac,                         :name => "PAC",            :description => "PAC sem contrato"                  },
+        "04510" => { :type => :pac,                         :name => "PAC",            :description => "PAC sem contrato"                  },
         "41068" => { :type => :pac_com_contrato,            :name => "PAC",            :description => "PAC com contrato"                  },
         "41300" => { :type => :pac_gf,                      :name => "PAC GF",         :description => "PAC para grandes formatos"         },
-        "40010" => { :type => :sedex,                       :name => "SEDEX",          :description => "SEDEX sem contrato"                },
+        "04014" => { :type => :sedex,                       :name => "SEDEX",          :description => "SEDEX sem contrato"                },
         "40045" => { :type => :sedex_a_cobrar,              :name => "SEDEX a Cobrar", :description => "SEDEX a Cobrar, sem contrato"      },
         "40126" => { :type => :sedex_a_cobrar_com_contrato, :name => "SEDEX a Cobrar", :description => "SEDEX a Cobrar, com contrato"      },
         "40215" => { :type => :sedex_10,                    :name => "SEDEX 10",       :description => "SEDEX 10, sem contrato"            },

--- a/lib/correios/frete/version.rb
+++ b/lib/correios/frete/version.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 module Correios
   module Frete
-    VERSION = "1.10.1"
+    VERSION = "1.10.2"
   end
 end

--- a/spec/correios/frete/parser_spec.rb
+++ b/spec/correios/frete/parser_spec.rb
@@ -10,7 +10,7 @@ describe Correios::Frete::Parser do
     end
 
     { :pac => { :tipo => :pac,
-                :codigo => "41106",
+                :codigo => "04510",
                 :valor => 15.70,
                 :prazo_entrega => 3,
                 :valor_mao_propria => 3.75,
@@ -21,7 +21,7 @@ describe Correios::Frete::Parser do
                 :erro => "-3",
                 :msg_erro => "Somente para teste" },
       :sedex => { :tipo => :sedex,
-                  :codigo => "40010",
+                  :codigo => "04014",
                   :valor => 17.8,
                   :prazo_entrega => 1,
                   :valor_mao_propria => 3.70,

--- a/spec/correios/frete/servico_spec.rb
+++ b/spec/correios/frete/servico_spec.rb
@@ -6,7 +6,7 @@ describe Correios::Frete::Servico do
     context "when service exists" do
       before :each do
         @xml = """<cServico>
-                    <Codigo>41106</Codigo>
+                    <Codigo>04510</Codigo>
                     <Valor>15,70</Valor>
                     <PrazoEntrega>3</PrazoEntrega>
                     <ValorMaoPropria>3,75</ValorMaoPropria>
@@ -22,7 +22,7 @@ describe Correios::Frete::Servico do
       { :tipo => :pac,
         :nome => "PAC",
         :descricao => "PAC sem contrato",
-        :codigo => "41106",
+        :codigo => "04510",
         :valor => 15.70,
         :prazo_entrega => 3,
         :valor_mao_propria => 3.75,
@@ -42,7 +42,7 @@ describe Correios::Frete::Servico do
       context "and calculated value is greater than 999.99" do
         before :each do
           @xml = """<cServico>
-                      <Codigo>41106</Codigo>
+                      <Codigo>04510</Codigo>
                       <Valor>1.024,75</Valor>
                       <PrazoEntrega>3</PrazoEntrega>
                       <ValorMaoPropria>3,75</ValorMaoPropria>

--- a/spec/support/responses/success-response-many-services.xml
+++ b/spec/support/responses/success-response-many-services.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
 <Servicos>
   <cServico>
-    <Codigo>41106</Codigo>
+    <Codigo>04510</Codigo>
     <Valor>15,70</Valor>
     <PrazoEntrega>3</PrazoEntrega>
     <ValorMaoPropria>3,75</ValorMaoPropria>
@@ -13,7 +13,7 @@
     <MsgErro>Somente para teste</MsgErro>
   </cServico>
   <cServico>
-    <Codigo>40010</Codigo>
+    <Codigo>04014</Codigo>
     <Valor>17,80</Valor>
     <PrazoEntrega>1</PrazoEntrega>
     <ValorMaoPropria>3,70</ValorMaoPropria>

--- a/spec/support/responses/success-response-one-service.xml
+++ b/spec/support/responses/success-response-one-service.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
 <Servicos>
   <cServico>
-    <Codigo>40010</Codigo>
+    <Codigo>04014</Codigo>
     <Valor>17,80</Valor>
     <PrazoEntrega>1</PrazoEntrega>
     <ValorMaoPropria>3,70</ValorMaoPropria>


### PR DESCRIPTION
Fiz a substituição dos códigos do PAC e do SEDEX que foram atualizados home 05/05/2017
mesmo que #28 porém com Specs.